### PR TITLE
Fix typo 'Themistor'

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -568,7 +568,7 @@
   },
   {
     "id": "resistor-iec-thermistor",
-    "name": "Themistor",
+    "name": "Thermistor",
     "category": "RESISTOR",
     "standard": "IEC",
     "filename": "Resistor-IEC-Thermistor"


### PR DESCRIPTION
Awesome resource, thanks.

Noticed this minor typo in the manifest file. That good old' stealth rm ⇔ m ⇔ rn issue.